### PR TITLE
Print the result of convert() only when DEBUG=true

### DIFF
--- a/src/main/java/fr/free/nrw/jakaroma/Jakaroma.java
+++ b/src/main/java/fr/free/nrw/jakaroma/Jakaroma.java
@@ -133,7 +133,9 @@ public class Jakaroma {
                 buffer.append(" ");
             }
         }
-        System.out.println(buffer);
+        if (DEBUG) {
+            System.out.println(buffer);
+        }
         return buffer.toString();
     }
 

--- a/src/main/java/fr/free/nrw/jakaroma/Jakaroma.java
+++ b/src/main/java/fr/free/nrw/jakaroma/Jakaroma.java
@@ -30,7 +30,8 @@ public class Jakaroma {
 
         Jakaroma instance = new Jakaroma();
         instance.isPronunciation = true;
-        instance.convert(input, true, true);
+        String result = instance.convert(input, true, true);
+        System.out.println(result);
     }
 
     /**


### PR DESCRIPTION
`convert()` seems too noisy, e.g. printing the result of each conversion to stdout. This pull-requests changes that so that printing is done only when `DEBUG` is `true`.