### PR TITLE
Fix for transliteration of the name of OSM way 971134980

### DIFF
--- a/src/main/java/fr/free/nrw/jakaroma/Jakaroma.java
+++ b/src/main/java/fr/free/nrw/jakaroma/Jakaroma.java
@@ -166,7 +166,7 @@ public class Jakaroma {
         String surface = token.getSurface();
 
         if (surface.contains("ッ") && !surface.endsWith("ッ")) {
-            String[] splitTokenSurface = surface.split("ッ");
+            String[] splitTokenSurface = surface.split("[ッ]+");
             String romaji1 = kanaToRomaji.convert(splitTokenSurface[0]);
             String romaji2 = kanaToRomaji.convert(splitTokenSurface[1]);
             buffer.append(romaji1).append(romaji2.charAt(0)).append(romaji2);

--- a/src/test/java/fr/free/nrw/jakaroma/JakaromaTest.java
+++ b/src/test/java/fr/free/nrw/jakaroma/JakaromaTest.java
@@ -60,4 +60,12 @@ public class JakaromaTest {
     public void translateFullWidthToHalfWidth() {
         Assert.assertEquals("wifi", instance.convert("ｗｉｆｉ", false, false));
     }
+
+    @Test
+    public void translateOsmWay971134980() {
+        // see https://www.openstreetmap.org/way/971134980
+        String testInput = "キッッズスクール加古川つばめ保育園";
+
+        Assert.assertEquals("Kizzusuku-ruKakogawaTsubaMeHoikuen", instance.convert(testInput, false, true));
+    }
 }


### PR DESCRIPTION
This PR should fix #18.

It transliterates "キッッズスクール加古川つばめ保育園" (see `name` in https://www.openstreetmap.org/way/971134980) intro "Kizzusuku-ruKakogawaTsubaMeHoikuen".

I'm not sure whether the transliteration is correct, but at least `StringIndexOutOfBoundsException` is not raised.