### PR TITLE
Upgrade of JUnit from 4 to 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,9 @@
             <version>0.9.0</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <maven.compiler.release>8</maven.compiler.release>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.version>5.11.3</junit.version>
     </properties>
 
     <distributionManagement>
@@ -124,7 +125,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.3</version>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/fr/free/nrw/jakaroma/JakaromaTest.java
+++ b/src/test/java/fr/free/nrw/jakaroma/JakaromaTest.java
@@ -3,58 +3,68 @@ package fr.free.nrw.jakaroma;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class JakaromaTest {
 
     private final Jakaroma instance = new Jakaroma();
 
-    @Test
-    public void translate() {
-        String[] testInput = {"もらった", "ホッ", "すごっ", "ピッザ"};
-
-        assertEquals("Moratta", instance.convert(testInput[0], false, true));
-        assertEquals("Ho!", instance.convert(testInput[1], false, true));
-        assertEquals("Sug!", instance.convert(testInput[2], false, true));
-        assertEquals("Pizza", instance.convert(testInput[3], false, true));
+    @ParameterizedTest
+    @CsvSource({
+        "もらった, Moratta",
+        "ホッ, Ho!",
+        "すごっ, Sug!",
+        "ピッザ, Pizza"
+    })
+    public void translate(String in, String out) {
+        assertEquals(out, instance.convert(in, false, true));
     }
 
-    @Test
-    public void noTranslateForLatin() {
-        String[] testInput = {"cat", "dog", "Hello!"};
-
-        assertEquals("Cat", instance.convert(testInput[0], false, true));
-        assertEquals("Dog", instance.convert(testInput[1], false, true));
-        assertEquals("Hello!", instance.convert(testInput[2], false, true));
+    @ParameterizedTest
+    @CsvSource({
+        "cat, Cat",
+        "dog, Dog",
+        "Hello!, Hello!"
+    })
+    public void noTranslateForLatin(String in, String out) {
+        assertEquals(out, instance.convert(in, false, true));
     }
 
-    @Test
-    public void yetAnotherTranslate() {
-        String[] testInput = {"小学校", "昨夜", "証書", "正直", "三日間", "順調", "任意", "爪", "みっかかん", "さっぱり",
-        "ばっちり", "じゅんちょうに", "ジャガイモ", "ニンジン", "ワーフル", "ウェファ", "フィリピン", "プライバシー", "バッチリ", "ジュンチャン",
-                "祐介さんのモットーは「ｙｅｓ，　ｗｅ　ｃａｎ」と「ウィンブレドンや全日本大会で男女両方ともが勝つ」"};
+    @ParameterizedTest
+    @CsvSource({
+        "小学校, Shougakkou",
+        "昨夜, Sakuya",
+        "証書, Shousho",
+        "正直, Shoujiki",
+        "三日間, 三Nichikan",
+        "順調, Junchou",
+        "任意, Nini",
+        "爪, Tsume",
+        "みっかかん, Mikkakan",
+        "さっぱり, Sappari",
+        "ばっちり, BacchiRi",
+        "じゅんちょうに, JunChouNi",
+        "ジャガイモ, Jagaimo",
+        "ニンジン, Ninjin",
+        "ワーフル, Wa-furu",
+        "ウェファ, Uェfuァ",
+        "フィリピン, Firipin",
+        "プライバシー, Puraibashi-",
+        "バッチリ, Bacchiri",
+        "ジュンチャン, JunChan"
+    })
+    public void yetAnotherTranslate(String in, String out) {
+        assertEquals(out, instance.convert(in, false, true));
+    }
 
-        assertEquals("Shougakkou", instance.convert(testInput[0], false, true));
-        assertEquals("Sakuya", instance.convert(testInput[1], false, true));
-        assertEquals("Shousho", instance.convert(testInput[2], false, true));
-        assertEquals("Shoujiki", instance.convert(testInput[3], false, true));
-        assertEquals("三Nichikan", instance.convert(testInput[4], false, true));
-        assertEquals("Junchou", instance.convert(testInput[5], false, true));
-        assertEquals("Nini", instance.convert(testInput[6], false, true));
-        assertEquals("Tsume", instance.convert(testInput[7], false, true));
-        assertEquals("Mikkakan", instance.convert(testInput[8], false, true));
-        assertEquals("Sappari", instance.convert(testInput[9], false, true));
-        assertEquals("BacchiRi", instance.convert(testInput[10], false, true));
-        assertEquals("JunChouNi", instance.convert(testInput[11], false, true));
-        assertEquals("Jagaimo", instance.convert(testInput[12], false, true));
-        assertEquals("Ninjin", instance.convert(testInput[13], false, true));
-        assertEquals("Wa-furu", instance.convert(testInput[14], false, true));
-        assertEquals("Uェfuァ", instance.convert(testInput[15], false, true));
-        assertEquals("Firipin", instance.convert(testInput[16], false, true));
-        assertEquals("Puraibashi-", instance.convert(testInput[17], false, true));
-        assertEquals("Bacchiri", instance.convert(testInput[18], false, true));
-        assertEquals("JunChan", instance.convert(testInput[19], false, true));
-        assertEquals("Yuusuke San No Motto- Ha \"Yes , We  Can \"To \"Uィnburedon Ya Zennihon Taikai De Danjo Ryouhou Tomo Ga Katsu \"", instance.convert(testInput[20], true, true));
-        assertEquals(".;\"\"", instance.convert("。；「」", true, true));
+    @ParameterizedTest
+    @CsvSource({
+        "祐介さんのモットーは「ｙｅｓ，　ｗｅ　ｃａｎ」と「ウィンブレドンや全日本大会で男女両方ともが勝つ」, 'Yuusuke San No Motto- Ha \"Yes , We  Can \"To \"Uィnburedon Ya Zennihon Taikai De Danjo Ryouhou Tomo Ga Katsu \"'",
+        "。；「」, .;\"\""
+    })
+    public void andYetAnotherTranslate(String in, String out) {
+        assertEquals(out, instance.convert(in, true, true));
     }
 
     @Test

--- a/src/test/java/fr/free/nrw/jakaroma/JakaromaTest.java
+++ b/src/test/java/fr/free/nrw/jakaroma/JakaromaTest.java
@@ -1,7 +1,8 @@
 package fr.free.nrw.jakaroma;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class JakaromaTest {
 
@@ -11,19 +12,19 @@ public class JakaromaTest {
     public void translate() {
         String[] testInput = {"もらった", "ホッ", "すごっ", "ピッザ"};
 
-        Assert.assertEquals("Moratta", instance.convert(testInput[0], false, true));
-        Assert.assertEquals("Ho!", instance.convert(testInput[1], false, true));
-        Assert.assertEquals("Sug!", instance.convert(testInput[2], false, true));
-        Assert.assertEquals("Pizza", instance.convert(testInput[3], false, true));
+        assertEquals("Moratta", instance.convert(testInput[0], false, true));
+        assertEquals("Ho!", instance.convert(testInput[1], false, true));
+        assertEquals("Sug!", instance.convert(testInput[2], false, true));
+        assertEquals("Pizza", instance.convert(testInput[3], false, true));
     }
 
     @Test
     public void noTranslateForLatin() {
         String[] testInput = {"cat", "dog", "Hello!"};
 
-        Assert.assertEquals("Cat", instance.convert(testInput[0], false, true));
-        Assert.assertEquals("Dog", instance.convert(testInput[1], false, true));
-        Assert.assertEquals("Hello!", instance.convert(testInput[2], false, true));
+        assertEquals("Cat", instance.convert(testInput[0], false, true));
+        assertEquals("Dog", instance.convert(testInput[1], false, true));
+        assertEquals("Hello!", instance.convert(testInput[2], false, true));
     }
 
     @Test
@@ -32,40 +33,38 @@ public class JakaromaTest {
         "ばっちり", "じゅんちょうに", "ジャガイモ", "ニンジン", "ワーフル", "ウェファ", "フィリピン", "プライバシー", "バッチリ", "ジュンチャン",
                 "祐介さんのモットーは「ｙｅｓ，　ｗｅ　ｃａｎ」と「ウィンブレドンや全日本大会で男女両方ともが勝つ」"};
 
-        Assert.assertEquals("Shougakkou", instance.convert(testInput[0], false, true));
-        Assert.assertEquals("Sakuya", instance.convert(testInput[1], false, true));
-        Assert.assertEquals("Shousho", instance.convert(testInput[2], false, true));
-        Assert.assertEquals("Shoujiki", instance.convert(testInput[3], false, true));
-        Assert.assertEquals("三Nichikan", instance.convert(testInput[4], false, true));
-        Assert.assertEquals("Junchou", instance.convert(testInput[5], false, true));
-        Assert.assertEquals("Nini", instance.convert(testInput[6], false, true));
-        Assert.assertEquals("Tsume", instance.convert(testInput[7], false, true));
-        Assert.assertEquals("Mikkakan", instance.convert(testInput[8], false, true));
-        Assert.assertEquals("Sappari", instance.convert(testInput[9], false, true));
-        Assert.assertEquals("BacchiRi", instance.convert(testInput[10], false, true));
-        Assert.assertEquals("JunChouNi", instance.convert(testInput[11], false, true));
-        Assert.assertEquals("Jagaimo", instance.convert(testInput[12], false, true));
-        Assert.assertEquals("Ninjin", instance.convert(testInput[13], false, true));
-        Assert.assertEquals("Wa-furu", instance.convert(testInput[14], false, true));
-        Assert.assertEquals("Uェfuァ", instance.convert(testInput[15], false, true));
-        Assert.assertEquals("Firipin", instance.convert(testInput[16], false, true));
-        Assert.assertEquals("Puraibashi-", instance.convert(testInput[17], false, true));
-        Assert.assertEquals("Bacchiri", instance.convert(testInput[18], false, true));
-        Assert.assertEquals("JunChan", instance.convert(testInput[19], false, true));
-        Assert.assertEquals("Yuusuke San No Motto- Ha \"Yes , We  Can \"To \"Uィnburedon Ya Zennihon Taikai De Danjo Ryouhou Tomo Ga Katsu \"", instance.convert(testInput[20], true, true));
-        Assert.assertEquals(".;\"\"", instance.convert("。；「」", true, true));
+        assertEquals("Shougakkou", instance.convert(testInput[0], false, true));
+        assertEquals("Sakuya", instance.convert(testInput[1], false, true));
+        assertEquals("Shousho", instance.convert(testInput[2], false, true));
+        assertEquals("Shoujiki", instance.convert(testInput[3], false, true));
+        assertEquals("三Nichikan", instance.convert(testInput[4], false, true));
+        assertEquals("Junchou", instance.convert(testInput[5], false, true));
+        assertEquals("Nini", instance.convert(testInput[6], false, true));
+        assertEquals("Tsume", instance.convert(testInput[7], false, true));
+        assertEquals("Mikkakan", instance.convert(testInput[8], false, true));
+        assertEquals("Sappari", instance.convert(testInput[9], false, true));
+        assertEquals("BacchiRi", instance.convert(testInput[10], false, true));
+        assertEquals("JunChouNi", instance.convert(testInput[11], false, true));
+        assertEquals("Jagaimo", instance.convert(testInput[12], false, true));
+        assertEquals("Ninjin", instance.convert(testInput[13], false, true));
+        assertEquals("Wa-furu", instance.convert(testInput[14], false, true));
+        assertEquals("Uェfuァ", instance.convert(testInput[15], false, true));
+        assertEquals("Firipin", instance.convert(testInput[16], false, true));
+        assertEquals("Puraibashi-", instance.convert(testInput[17], false, true));
+        assertEquals("Bacchiri", instance.convert(testInput[18], false, true));
+        assertEquals("JunChan", instance.convert(testInput[19], false, true));
+        assertEquals("Yuusuke San No Motto- Ha \"Yes , We  Can \"To \"Uィnburedon Ya Zennihon Taikai De Danjo Ryouhou Tomo Ga Katsu \"", instance.convert(testInput[20], true, true));
+        assertEquals(".;\"\"", instance.convert("。；「」", true, true));
     }
 
     @Test
     public void translateFullWidthToHalfWidth() {
-        Assert.assertEquals("wifi", instance.convert("ｗｉｆｉ", false, false));
+        assertEquals("wifi", instance.convert("ｗｉｆｉ", false, false));
     }
 
     @Test
     public void translateOsmWay971134980() {
         // see https://www.openstreetmap.org/way/971134980
-        String testInput = "キッッズスクール加古川つばめ保育園";
-
-        Assert.assertEquals("Kizzusuku-ruKakogawaTsubaMeHoikuen", instance.convert(testInput, false, true));
+        assertEquals("Kizzusuku-ruKakogawaTsubaMeHoikuen", instance.convert("キッッズスクール加古川つばめ保育園", false, true));
     }
 }

--- a/src/test/java/fr/free/nrw/jakaroma/KanaToRomajiTest.java
+++ b/src/test/java/fr/free/nrw/jakaroma/KanaToRomajiTest.java
@@ -2,38 +2,29 @@ package fr.free.nrw.jakaroma;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class KanaToRomajiTest {
 
     private final KanaToRomaji k2r = new KanaToRomaji();
 
-    @Test
-    public void translate() {
-        String[] strs = {"ピュートフクジャガー",
-                "マージャン",
-                "タンヤオトイトイドラドラ",
-                "キップ",
-                "プリキュア",
-                "シャーペン",
-                "カプッ",
-                "@マーク",
-                "ティーカップ",
-                "ビルディング",
-                "ロッポンギヒルズ",
-                "トッツィ"};
-
-        assertEquals("pyu-tofukujaga-", k2r.convert(strs[0]));
-        assertEquals("ma-jan", k2r.convert(strs[1]));
-        assertEquals("tanyaotoitoidoradora", k2r.convert(strs[2]));
-        assertEquals("kippu", k2r.convert(strs[3]));
-        assertEquals("purikyua", k2r.convert(strs[4]));
-        assertEquals("sha-pen", k2r.convert(strs[5]));
-        assertEquals("kapuッ", k2r.convert(strs[6]));
-        assertEquals("@ma-ku", k2r.convert(strs[7]));
-        assertEquals("ti-kappu", k2r.convert(strs[8]));
-        assertEquals("birudingu", k2r.convert(strs[9]));
-        assertEquals("roppongihiruzu", k2r.convert(strs[10]));
-        assertEquals("tottsi", k2r.convert(strs[11]));
+    @ParameterizedTest
+    @CsvSource({
+        "ピュートフクジャガー, pyu-tofukujaga-",
+        "マージャン, ma-jan",
+        "タンヤオトイトイドラドラ, tanyaotoitoidoradora",
+        "キップ, kippu",
+        "プリキュア, purikyua",
+        "シャーペン, sha-pen",
+        "カプッ, kapuッ",
+        "@マーク, @ma-ku",
+        "ティーカップ, ti-kappu",
+        "ビルディング, birudingu",
+        "ロッポンギヒルズ, roppongihiruzu",
+        "トッツィ, tottsi"
+    })
+    public void translate(String in, String out) {
+        assertEquals(out, k2r.convert(in));
     }
 }

--- a/src/test/java/fr/free/nrw/jakaroma/KanaToRomajiTest.java
+++ b/src/test/java/fr/free/nrw/jakaroma/KanaToRomajiTest.java
@@ -1,7 +1,8 @@
 package fr.free.nrw.jakaroma;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class KanaToRomajiTest {
 
@@ -22,17 +23,17 @@ public class KanaToRomajiTest {
                 "ロッポンギヒルズ",
                 "トッツィ"};
 
-        Assert.assertEquals("pyu-tofukujaga-", k2r.convert(strs[0]));
-        Assert.assertEquals("ma-jan", k2r.convert(strs[1]));
-        Assert.assertEquals("tanyaotoitoidoradora", k2r.convert(strs[2]));
-        Assert.assertEquals("kippu", k2r.convert(strs[3]));
-        Assert.assertEquals("purikyua", k2r.convert(strs[4]));
-        Assert.assertEquals("sha-pen", k2r.convert(strs[5]));
-        Assert.assertEquals("kapuッ", k2r.convert(strs[6]));
-        Assert.assertEquals("@ma-ku", k2r.convert(strs[7]));
-        Assert.assertEquals("ti-kappu", k2r.convert(strs[8]));
-        Assert.assertEquals("birudingu", k2r.convert(strs[9]));
-        Assert.assertEquals("roppongihiruzu", k2r.convert(strs[10]));
-        Assert.assertEquals("tottsi", k2r.convert(strs[11]));
+        assertEquals("pyu-tofukujaga-", k2r.convert(strs[0]));
+        assertEquals("ma-jan", k2r.convert(strs[1]));
+        assertEquals("tanyaotoitoidoradora", k2r.convert(strs[2]));
+        assertEquals("kippu", k2r.convert(strs[3]));
+        assertEquals("purikyua", k2r.convert(strs[4]));
+        assertEquals("sha-pen", k2r.convert(strs[5]));
+        assertEquals("kapuッ", k2r.convert(strs[6]));
+        assertEquals("@ma-ku", k2r.convert(strs[7]));
+        assertEquals("ti-kappu", k2r.convert(strs[8]));
+        assertEquals("birudingu", k2r.convert(strs[9]));
+        assertEquals("roppongihiruzu", k2r.convert(strs[10]));
+        assertEquals("tottsi", k2r.convert(strs[11]));
     }
 }


### PR DESCRIPTION
This PR contains:

- Update of JUnit from 4.13.1 to 5.11.3
- Adjustment of unit tests for the updated JUnit API
- Adjustment of unit tests to utilize `@ParameterizedTest` `@CsvSource` to (hopefully) simplify the tests and make it (slightly) easier to work with them

All else is same, e.g. this is just maintenance/clean-up.